### PR TITLE
Fix multi-row navbar

### DIFF
--- a/poxy/data/poxy.css
+++ b/poxy/data/poxy.css
@@ -1,6 +1,13 @@
+html {
+	height:100%;
+}
+
+body {
+	min-height:100%;
+}
+
 html, body
 {
-	height: 100%;
 	scroll-padding-top: 3.5rem;
 }
 
@@ -8,12 +15,11 @@ body
 {
 	display: flex;
 	flex-direction: column;
-	padding-top: 3rem;
 }
 
 body > header
 {
-	position: fixed;
+	position: sticky;
 	top: 0;
 	left: 0;
 	right: 0;


### PR DESCRIPTION
We use sticky to offset the header from its closest scrolling ancestor, then we set the footer by defining the minimum and maximum heights of the document. The padding-top is removed due to conflicting positioning. 

Fix https://github.com/marzer/poxy/issues/3

![Screenshot 2022-08-15 192416](https://user-images.githubusercontent.com/91024200/184740381-222e9880-0ead-4751-adeb-688e84f70758.png)
