### PR TITLE
Remove excessive padding and text in github icon

### DIFF
--- a/poxy/data/poxy.css
+++ b/poxy/data/poxy.css
@@ -75,11 +75,13 @@ nav .m-thin
 }
 nav .github
 {
-	padding-left: 44px !important;
+	margin-left: 15px !important;
+	background-image: url("poxy-github.svg");
 	background-repeat: no-repeat;
-	background-size: 25px 25px;
-	background-position: -30px center;
-	background-origin: content-box;
+	background-size: 15px 15px;
+	background-position: center center;
+	color: transparent !important;
+	width: 50px !important;
 }
 @media screen and (max-width: 576px)
 {

--- a/poxy/data/poxy.css
+++ b/poxy/data/poxy.css
@@ -47,11 +47,6 @@ a
 	text-decoration: none !important;
 }
 
-article div > section
-{
-	margin-top: 4rem;
-}
-
 article div > section > section
 {
 	margin-bottom: 2.25rem;


### PR DESCRIPTION
see: https://github.com/marzer/poxy/pull/5#issuecomment-1236397268

~The padding is excessively large for article sections. Since I'm not sure if this was intended or if it's a slight shape defect, I thought it best to open this up for investigation:~

(main) margin-top: 4rem            |  (patch) margin-top: 2rem
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/91024200/188290194-5cfbdd5c-8698-46f2-8fb0-1beee9caf1f7.png)  |  ![](https://user-images.githubusercontent.com/91024200/188290195-764323b1-d6f2-48da-8b9d-9debfe832c9c.png)

