### PR TITLE
Add ixx module extension in source patterns

### DIFF
--- a/poxy/project.py
+++ b/poxy/project.py
@@ -585,7 +585,7 @@ class Defaults(object):
 		r'm_enum_values_as_keywords' : r'@xmlonly<mcss:search xmlns:mcss="http://mcss.mosra.cz/doxygen/" mcss:enum-values-as-keywords="true" />@endxmlonly'
 	}
 	source_patterns = {
-		r'*.h', r'*.hh', r'*.hxx', r'*.hpp', r'*.h++', r'*.inc', r'*.markdown', r'*.md', r'*.dox'
+		r'*.h', r'*.hh', r'*.hxx', r'*.hpp', r'*.h++', r'*.ixx', r'*.inc', r'*.markdown', r'*.md', r'*.dox'
 	}
 	# code block syntax highlighting only
 	cb_enums = {


### PR DESCRIPTION
As things get better with C++ modules, it may now be useful to add support for the _ixx_ module extension. Unlike a typical translation unit, there is no header separation for writing the documentation. This means that we must either A: write the documentation inline in the module, or B: write the documentation off-source in .dox files. Whichever choice we make, the module extension, just like the headers previously used, must be parsed by doxygen.

![image](https://user-images.githubusercontent.com/91024200/189464226-ef7d08ba-8b15-4f9e-bc58-75d0aa174174.png)
