### PR TITLE
Restore compatibility with Python <3.9

### DIFF
--- a/poxy/main.py
+++ b/poxy/main.py
@@ -97,10 +97,15 @@ def main(invoker=True):
 	)
 	args.add_argument(
 		r'--html',  #
-		default=True,
-		action=argparse.BooleanOptionalAction,
+		action=r'store_true',
 		help=r'specify whether HTML output is required'
 	)
+	args.add_argument(
+		r'--no-html',
+		dest=r'html',
+		action=r'store_false'
+	)
+	args.set_defaults(html=True)
 	args.add_argument(
 		r'--ppinclude',  #
 		type=str,
@@ -136,16 +141,26 @@ def main(invoker=True):
 	)
 	args.add_argument(
 		r'--xml',  #
-		default=False,
-		action=argparse.BooleanOptionalAction,
+		action=r'store_true',
 		help=r'specify whether XML output is required'
 	)
 	args.add_argument(
+		r'--no-xml',
+		dest=r'xml',
+		action=r'store_false'
+	)
+	args.set_defaults(xml=False)
+	args.add_argument(
 		r'--werror',  #
-		default=None,
-		action=argparse.BooleanOptionalAction,
+		action=r'store_true',
 		help=r"override the treating of warnings as errors (default: read from config)"
 	)
+	args.add_argument(
+		r'--no-werror',
+		dest=r'werror',
+		action=r'store_false'
+	)
+	args.set_defaults(werror=None)
 	args.add_argument(
 		r'--bug-report', action=r'store_true', help=r"captures all output in a zip file for easier bug reporting."
 	)


### PR DESCRIPTION
Hi Mark,

many thanks for this extremely useful wrapper around m.css!

I am stuck with Python v3.8 in some of my projects and stumbled over `argparse.BooleanOptionalAction`—which has only been introduced in Python v3.9. I hope you could consider merging this tiny PR to get back compatibility with earlier versions of Python.

Functionality and CLI arguments are not affected; the only downside is that `--no-{html,xml,werror}` are now listed on a separate line below their positive counterparts, e.g.:

```
[...]
  -v, --verbose         enable very noisy diagnostic output
  --html                specify whether HTML output is required
  --no-html
  --ppinclude <regex>   pattern matching HTML file names to post-process (default: all)
[...]
```

Cheers, Felix